### PR TITLE
Identify execution bugs in codebase

### DIFF
--- a/code_review1129.md
+++ b/code_review1129.md
@@ -1,0 +1,343 @@
+# Kosmos Codebase Code Review - November 29, 2025
+
+## Executive Summary
+
+This code review focuses on identifying bugs that would prevent execution. The review found **4 critical issues** that would cause immediate crashes when specific modules are loaded, along with several medium and low severity issues.
+
+---
+
+## CRITICAL SEVERITY - Immediate Crash Issues
+
+### Issue #1: Import Statement Inside Docstring (result.py)
+
+**File:** `kosmos/models/result.py`
+**Lines:** 2-3
+**Error Type:** `NameError: name 'model_to_dict' is not defined`
+
+**Problematic Code:**
+```python
+"""Experiment result data models.
+from kosmos.utils.compat import model_to_dict
+Defines Pydantic models for experiment results...
+"""
+```
+
+**What's Wrong:**
+The import statement `from kosmos.utils.compat import model_to_dict` is embedded inside the module docstring. Python treats this as part of the docstring text, not as an actual import statement. The import never executes.
+
+**Where It Breaks:**
+Line 242 in the `to_dict()` method of `ExperimentResult`:
+```python
+def to_dict(self) -> Dict[str, Any]:
+    """Convert to dictionary for database storage."""
+    return model_to_dict(self, mode='json', exclude_none=True)
+```
+
+**Impact:** Any code that calls `ExperimentResult.to_dict()` will crash with `NameError`. This affects experiment result serialization and database storage.
+
+---
+
+### Issue #2: Import Statement Inside Docstring (executor.py)
+
+**File:** `kosmos/execution/executor.py`
+**Lines:** 2-3
+**Error Type:** `NameError: name 'model_to_dict' is not defined`
+
+**Problematic Code:**
+```python
+"""
+Code execution engine.
+from kosmos.utils.compat import model_to_dict
+
+Executes generated Python code safely...
+"""
+```
+
+**What's Wrong:**
+Same issue - the import is inside the docstring and never executes.
+
+**Where It Breaks:**
+Line 67 in `ExecutionResult.to_dict()`:
+```python
+def to_dict(self) -> Dict[str, Any]:
+    ...
+    if self.profile_result:
+        try:
+            result['profile_data'] = model_to_dict(self.profile_result)
+        except Exception:
+            result['profile_data'] = None
+```
+
+**Impact:** When an `ExecutionResult` with `profile_result` data calls `to_dict()`, it will raise `NameError`. The try/except catches it but sets `profile_data` to `None`, silently losing profiling data.
+
+---
+
+### Issue #3: Import Statement Inside Docstring (reproducibility.py)
+
+**File:** `kosmos/safety/reproducibility.py`
+**Lines:** 2-3
+**Error Type:** `NameError: name 'model_to_dict' is not defined`
+
+**Problematic Code:**
+```python
+"""
+Reproducibility management and validation.
+from kosmos.utils.compat import model_to_dict
+
+Implements:
+- Random seed management
+...
+"""
+```
+
+**What's Wrong:**
+Same pattern - import inside docstring.
+
+**Where It Breaks:**
+Line 51 in `EnvironmentSnapshot.to_dict()`:
+```python
+def to_dict(self) -> Dict[str, Any]:
+    """Convert to dictionary."""
+    return model_to_dict(self)
+```
+
+**Impact:** `EnvironmentSnapshot.to_dict()` calls will crash. This affects reproducibility reporting and environment export functionality.
+
+---
+
+### Issue #4: Import Statement Inside Docstring (profile.py)
+
+**File:** `kosmos/cli/commands/profile.py`
+**Lines:** 2-3
+**Error Type:** `NameError: name 'model_to_dict' is not defined`
+
+**Problematic Code:**
+```python
+"""
+Profile command for performance analysis.
+from kosmos.utils.compat import model_to_dict
+
+Displays profiling results...
+"""
+```
+
+**What's Wrong:**
+Same pattern - import inside docstring.
+
+**Where It Breaks:**
+Line 474 in `_save_profile_output()`:
+```python
+def _save_profile_output(profile: ProfileResult, output_path: Path):
+    try:
+        with open(output_path, 'w') as f:
+            json.dump(model_to_dict(profile), f, indent=2, default=str)
+```
+
+**Impact:** The `kosmos profile` CLI command will crash when trying to save profile output to a file.
+
+---
+
+## MEDIUM SEVERITY Issues
+
+### Issue #5: Potential Import Conflict in execution/__init__.py
+
+**File:** `kosmos/execution/__init__.py`
+**Lines:** 51, 81
+**Error Type:** Naming conflict
+
+**Problematic Code:**
+```python
+from .jupyter_client import (
+    ...
+    ExecutionResult,   # Line 51
+    ...
+)
+
+from .executor import (
+    ...
+    ExecutionResult as LegacyExecutionResult,  # Line 81
+    ...
+)
+```
+
+**What's Wrong:**
+The module imports `ExecutionResult` from two different places. While it aliases one as `LegacyExecutionResult`, code that doesn't use the alias properly could get the wrong class.
+
+**Impact:** Potential runtime confusion if code incorrectly references `ExecutionResult` expecting the legacy version.
+
+---
+
+### Issue #6: Optional Dependency Not Gracefully Handled
+
+**File:** `kosmos/core/async_llm.py`
+**Lines:** 17-24
+**Error Type:** Potential `TypeError` on exception handling
+
+**Problematic Code:**
+```python
+try:
+    from anthropic import AsyncAnthropic, APIError, APITimeoutError, RateLimitError
+    ASYNC_ANTHROPIC_AVAILABLE = True
+except ImportError:
+    ASYNC_ANTHROPIC_AVAILABLE = False
+    APIError = Exception
+    APITimeoutError = Exception
+    RateLimitError = Exception
+```
+
+**What's Wrong:**
+When anthropic is not installed, `APIError`, `APITimeoutError`, and `RateLimitError` are all set to `Exception`. Later in the code (lines 149-160), these are used in `isinstance()` checks. Since they all point to the same class (`Exception`), the checks become meaningless and could catch unintended exceptions.
+
+**Impact:** Without the anthropic package, error handling logic is degraded and may behave unexpectedly.
+
+---
+
+### Issue #7: World Model Entity Conversion May Fail
+
+**File:** `kosmos/world_model/simple.py`
+**Line:** 631
+**Error Type:** Potential `AttributeError`
+
+**Problematic Code:**
+```python
+entity = self._node_to_entity(node, entity_type)
+entities.append(entity.to_dict())
+```
+
+**What's Wrong:**
+The `Entity` model's `to_dict()` method is called, but looking at `kosmos/world_model/models.py`, the `Entity` class may not have a `to_dict()` method defined or it may call `model_to_dict` which has the docstring import bug.
+
+**Impact:** Graph export operations may fail.
+
+---
+
+## LOW SEVERITY Issues
+
+### Issue #8: Hardcoded Default Values May Be Inappropriate
+
+**File:** `kosmos/config.py`
+**Lines:** Various
+
+**Example:**
+```python
+_DEFAULT_CLAUDE_SONNET_MODEL = "claude-sonnet-4-20250514"
+```
+
+**What's Wrong:**
+Model names are hardcoded. If Anthropic deprecates these model names, the code will break.
+
+**Impact:** Future compatibility issues when model names change.
+
+---
+
+### Issue #9: Missing Type Hints for Return Values
+
+**File:** `kosmos/cli/utils.py`
+**Line:** 201
+
+**Problematic Code:**
+```python
+def create_table(
+    title: str,
+    columns: List[str],
+    rows: List[List[Any]] = None,  # Mutable default argument
+    ...
+) -> Table:
+```
+
+**What's Wrong:**
+Using `None` as default is fine, but the pattern `rows: List[List[Any]] = None` is slightly misleading since the type hint says `List` but default is `None`. Should be `Optional[List[List[Any]]] = None`.
+
+**Impact:** Type checking tools may flag this as an error.
+
+---
+
+### Issue #10: Database Session Context Manager Relies on Import Inside Function
+
+**File:** `kosmos/cli/utils.py`
+**Lines:** 249-260
+
+**Code:**
+```python
+@contextmanager
+def get_db_session():
+    from kosmos.db import get_session
+    with get_session() as session:
+        yield session
+```
+
+**What's Wrong:**
+The import is inside the function to avoid circular imports, but if `kosmos.db` has issues, the error won't be caught until runtime when this function is called.
+
+**Impact:** Delayed error discovery; errors only surface when database operations are attempted.
+
+---
+
+## Documentation Issues
+
+### Issue #11: Stale Import in Docstring Examples
+
+**File:** Multiple files
+
+Several docstrings show import examples that may not match actual module structure. For example, docstrings reference imports that no longer exist or have been renamed.
+
+---
+
+## Summary Table
+
+| # | Severity | File | Issue | Error Type |
+|---|----------|------|-------|------------|
+| 1 | CRITICAL | models/result.py:3 | Import in docstring | NameError |
+| 2 | CRITICAL | execution/executor.py:3 | Import in docstring | NameError |
+| 3 | CRITICAL | safety/reproducibility.py:3 | Import in docstring | NameError |
+| 4 | CRITICAL | cli/commands/profile.py:3 | Import in docstring | NameError |
+| 5 | MEDIUM | execution/__init__.py | Naming conflict | Confusion |
+| 6 | MEDIUM | core/async_llm.py | Fallback exception handling | Logic error |
+| 7 | MEDIUM | world_model/simple.py:631 | to_dict may fail | AttributeError |
+| 8 | LOW | config.py | Hardcoded model names | Future breakage |
+| 9 | LOW | cli/utils.py:201 | Type hint mismatch | Type error |
+| 10 | LOW | cli/utils.py:249 | Delayed import | Late error |
+| 11 | LOW | Multiple | Stale docstrings | Documentation |
+
+---
+
+## Recommended Fix Priority
+
+1. **Immediate (P0):** Fix Issues #1-4 - The import statements inside docstrings. These will cause immediate `NameError` crashes when the affected code paths are executed.
+
+2. **Soon (P1):** Fix Issue #5-7 - These could cause subtle bugs or unexpected behavior.
+
+3. **Later (P2):** Fix Issues #8-11 - These are code quality issues that don't block execution.
+
+---
+
+## How to Fix Critical Issues #1-4
+
+For each affected file, move the import statement **outside** the docstring and place it with the other imports at the top of the file:
+
+**Before:**
+```python
+"""
+Module docstring.
+from kosmos.utils.compat import model_to_dict
+
+More docstring text...
+"""
+```
+
+**After:**
+```python
+"""
+Module docstring.
+
+More docstring text...
+"""
+
+from kosmos.utils.compat import model_to_dict
+```
+
+Or add it to the existing imports section if there is one.
+
+---
+
+*Review conducted: November 29, 2025*


### PR DESCRIPTION
Document 4 critical issues where import statements are incorrectly placed inside docstrings, causing NameError when those code paths execute. Also identify 3 medium severity issues and 4 low severity issues affecting code quality and future maintainability.