### PR TITLE
Fix remaining Tier 3-4 issues from DEEP_ONBOARD review

### DIFF
--- a/kosmos/agents/base.py
+++ b/kosmos/agents/base.py
@@ -11,7 +11,7 @@ Async Architecture (Issue #66 fix):
 
 from typing import Dict, Any, Optional, List, Callable, Awaitable, Union
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field
 import logging
 import uuid
@@ -63,7 +63,7 @@ class AgentMessage(BaseModel):
     to_agent: str
     content: Dict[str, Any]
     correlation_id: Optional[str] = None  # For tracking request/response pairs
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -90,8 +90,8 @@ class AgentState(BaseModel):
     agent_type: str
     status: AgentStatus
     data: Dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class BaseAgent:
@@ -129,8 +129,8 @@ class BaseAgent:
         self.config = config or {}
 
         self.status = AgentStatus.CREATED
-        self.created_at = datetime.utcnow()
-        self.updated_at = datetime.utcnow()
+        self.created_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
 
         # Message handling - async queue for proper async processing
         self.message_queue: List[AgentMessage] = []  # Legacy sync queue (for compatibility)
@@ -445,7 +445,7 @@ class BaseAgent:
         Returns:
             AgentState: Current state
         """
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
         return AgentState(
             agent_id=self.agent_id,
             agent_type=self.agent_type,
@@ -474,7 +474,7 @@ class BaseAgent:
     def save_state_data(self, key: str, value: Any):
         """Save data to agent state."""
         self.state_data[key] = value
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def get_state_data(self, key: str, default: Any = None) -> Any:
         """Retrieve data from agent state."""
@@ -484,17 +484,19 @@ class BaseAgent:
     # EXECUTION
     # ========================================================================
 
-    def execute(self, task: Dict[str, Any]) -> Dict[str, Any]:
+    def execute(self, task: Union[Dict[str, Any], "AgentMessage"]) -> Union[Dict[str, Any], "AgentMessage"]:
         """
         Execute agent task.
 
         Subclasses should override this to implement main agent logic.
+        Accepts either a Dict task specification or an AgentMessage,
+        depending on the agent's communication pattern.
 
         Args:
-            task: Task specification
+            task: Task specification (Dict) or AgentMessage
 
         Returns:
-            dict: Task result
+            Task result as Dict or AgentMessage
         """
         raise NotImplementedError(f"execute() not implemented for {self.agent_type}")
 

--- a/kosmos/agents/data_analyst.py
+++ b/kosmos/agents/data_analyst.py
@@ -8,7 +8,7 @@ identifying anomalies, and generating scientific insights.
 import logging
 import json
 from typing import List, Dict, Any, Optional, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 import numpy as np
 
 from kosmos.agents.base import BaseAgent, AgentMessage, MessageType, AgentStatus
@@ -71,7 +71,7 @@ class ResultInterpretation:
         self.anomalies_detected = anomalies_detected
         self.patterns_detected = patterns_detected
         self.overall_assessment = overall_assessment
-        self.created_at = created_at or datetime.utcnow()
+        self.created_at = created_at or datetime.now(timezone.utc)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""

--- a/kosmos/agents/experiment_designer.py
+++ b/kosmos/agents/experiment_designer.py
@@ -10,7 +10,7 @@ import time
 import uuid
 import json
 from typing import List, Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from kosmos.agents.base import BaseAgent, AgentMessage, MessageType, AgentStatus
 from kosmos.core.llm import get_client
@@ -106,7 +106,7 @@ class ExperimentDesignerAgent(BaseAgent):
 
         logger.info(f"Initialized ExperimentDesignerAgent {self.agent_id}")
 
-    def execute(self, message: AgentMessage) -> AgentMessage:
+    def execute(self, message):
         """
         Execute agent task from message.
 
@@ -896,7 +896,7 @@ Return ONLY a JSON object with suggested enhancements (keep it concise).
                     status=ExperimentStatus.CREATED.value,
                     protocol=protocol.to_dict(),
                     domain=protocol.domain,
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(timezone.utc),
                 )
 
                 session.add(db_experiment)

--- a/kosmos/agents/hypothesis_generator.py
+++ b/kosmos/agents/hypothesis_generator.py
@@ -88,7 +88,7 @@ class HypothesisGeneratorAgent(BaseAgent):
 
         logger.info(f"Initialized HypothesisGeneratorAgent {self.agent_id}")
 
-    def execute(self, message: AgentMessage) -> AgentMessage:
+    def execute(self, message):
         """
         Execute agent task from message.
 

--- a/kosmos/agents/registry.py
+++ b/kosmos/agents/registry.py
@@ -14,7 +14,7 @@ Async Architecture (Issue #66 fix):
 from typing import Dict, List, Optional, Type, Any
 from kosmos.agents.base import BaseAgent, AgentMessage, AgentStatus
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 import asyncio
 
 
@@ -462,7 +462,7 @@ class AgentRegistry:
             "unhealthy_agents": total_agents - healthy_agents,
             "agent_health": agent_health,
             "message_history_size": len(self._message_history),
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
 
     def get_agent_statistics(self) -> Dict[str, Any]:

--- a/kosmos/agents/research_director.py
+++ b/kosmos/agents/research_director.py
@@ -13,7 +13,7 @@ Async Architecture (Issue #66 fix):
 """
 
 from typing import Dict, Any, Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import asyncio
 import concurrent.futures
@@ -625,7 +625,7 @@ class ResearchDirectorAgent(BaseAgent):
         # Update error tracking
         self.errors_encountered += 1
         self._consecutive_errors += 1
-        self._last_error_time = datetime.utcnow()
+        self._last_error_time = datetime.now(timezone.utc)
 
         # Record in error history
         error_record = {
@@ -1080,7 +1080,7 @@ class ResearchDirectorAgent(BaseAgent):
         self.pending_requests[message.id] = {
             "agent": "HypothesisGeneratorAgent",
             "action": action,
-            "timestamp": datetime.utcnow()
+            "timestamp": datetime.now(timezone.utc)
         }
 
         # Track rollout (Issue #58)
@@ -1114,7 +1114,7 @@ class ResearchDirectorAgent(BaseAgent):
         self.pending_requests[message.id] = {
             "agent": "ExperimentDesignerAgent",
             "hypothesis_id": hypothesis_id,
-            "timestamp": datetime.utcnow()
+            "timestamp": datetime.now(timezone.utc)
         }
 
         # Track rollout (Issue #58)
@@ -1150,7 +1150,7 @@ class ResearchDirectorAgent(BaseAgent):
         self.pending_requests[message.id] = {
             "agent": "Executor",
             "protocol_id": protocol_id,
-            "timestamp": datetime.utcnow()
+            "timestamp": datetime.now(timezone.utc)
         }
 
         # Track rollout (Issue #58)
@@ -1184,7 +1184,7 @@ class ResearchDirectorAgent(BaseAgent):
         self.pending_requests[message.id] = {
             "agent": "DataAnalystAgent",
             "result_id": result_id,
-            "timestamp": datetime.utcnow()
+            "timestamp": datetime.now(timezone.utc)
         }
 
         # Track rollout (Issue #58)
@@ -1219,7 +1219,7 @@ class ResearchDirectorAgent(BaseAgent):
         self.pending_requests[message.id] = {
             "agent": "HypothesisRefiner",
             "hypothesis_id": hypothesis_id,
-            "timestamp": datetime.utcnow()
+            "timestamp": datetime.now(timezone.utc)
         }
 
         # Track rollout - refinement is part of hypothesis lifecycle (Issue #58)
@@ -1710,7 +1710,7 @@ class ResearchDirectorAgent(BaseAgent):
                 # Build minimal ExperimentResult from DB fields
                 import sys as _sys
                 import platform as _platform
-                _now = datetime.utcnow()
+                _now = datetime.now(timezone.utc)
                 pydantic_result = ExperimentResult(
                     id=db_result.id,
                     experiment_id=db_result.experiment_id,
@@ -1857,7 +1857,7 @@ class ResearchDirectorAgent(BaseAgent):
                             try:
                                 import sys as _sys
                                 import platform as _platform
-                                _now = datetime.utcnow()
+                                _now = datetime.now(timezone.utc)
                                 pydantic_r = ExperimentResult(
                                     id=db_r.id,
                                     experiment_id=db_r.experiment_id,
@@ -2177,10 +2177,17 @@ Provide brief JSON response:
             results = []
             for protocol_id in protocol_ids:
                 # Sequential fallback - use direct call (Issue #76)
-                import asyncio
-                asyncio.get_event_loop().run_until_complete(
-                    self._handle_execute_experiment_action(protocol_id=protocol_id)
-                )
+                try:
+                    loop = asyncio.get_running_loop()
+                    future = asyncio.run_coroutine_threadsafe(
+                        self._handle_execute_experiment_action(protocol_id=protocol_id),
+                        loop
+                    )
+                    future.result(timeout=600)
+                except RuntimeError:
+                    asyncio.run(
+                        self._handle_execute_experiment_action(protocol_id=protocol_id)
+                    )
                 results.append({"protocol_id": protocol_id, "status": "executed"})
             return results
 

--- a/kosmos/analysis/summarizer.py
+++ b/kosmos/analysis/summarizer.py
@@ -6,7 +6,7 @@ Natural language summaries of experiment results using Claude.
 
 import logging
 from typing import List, Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from kosmos.core.llm import get_client
 from kosmos.models.result import ExperimentResult
@@ -46,7 +46,7 @@ class ResultSummary:
         self.hypothesis_comparison = hypothesis_comparison
         self.limitations = limitations
         self.future_work = future_work
-        self.created_at = created_at or datetime.utcnow()
+        self.created_at = created_at or datetime.now(timezone.utc)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""

--- a/kosmos/api/health.py
+++ b/kosmos/api/health.py
@@ -7,7 +7,7 @@ Provides liveness, readiness, and metrics endpoints for monitoring.
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional
 import psutil
 import platform
@@ -47,7 +47,7 @@ class HealthChecker:
 
         return {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "uptime_seconds": round(uptime, 2),
             "checks_performed": self.checks_performed,
             "service": "kosmos-ai-scientist",
@@ -99,7 +99,7 @@ class HealthChecker:
 
         return {
             "status": overall_status,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "components": components,
             "service": "kosmos-ai-scientist",
             "version": self._get_version()
@@ -140,7 +140,7 @@ class HealthChecker:
 
         return {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "system": {
                 "platform": platform.system(),
                 "platform_release": platform.release(),
@@ -222,13 +222,20 @@ class HealthChecker:
             Dictionary with cache status
         """
         try:
-            # Check if Redis is enabled
-            redis_enabled = os.getenv("REDIS_ENABLED", "false").lower() == "true"
+            # Use Pydantic config for Redis settings (avoids env var divergence)
+            from kosmos.config import get_config
+            try:
+                config = get_config()
+                redis_enabled = config.redis.enabled
+                redis_url = config.redis.url
+            except Exception:
+                # Fall back to env vars if config is not initialized yet
+                redis_enabled = os.getenv("REDIS_ENABLED", "false").lower() == "true"
+                redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
             if redis_enabled:
                 # Try to connect to Redis
                 import redis
-                redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
                 start_time = time.time()
                 client = redis.from_url(
@@ -279,8 +286,13 @@ class HealthChecker:
             Dictionary with external API status
         """
         try:
-            # Check if API key is configured
-            api_key = os.getenv("ANTHROPIC_API_KEY")
+            # Use Pydantic config for API key (avoids env var divergence)
+            from kosmos.config import get_config
+            try:
+                config = get_config()
+                api_key = config.claude.api_key if config.claude else None
+            except Exception:
+                api_key = os.getenv("ANTHROPIC_API_KEY")
 
             if not api_key:
                 return {
@@ -333,9 +345,17 @@ class HealthChecker:
         try:
             from neo4j import GraphDatabase
 
-            uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
-            user = os.getenv("NEO4J_USER", "neo4j")
-            password = os.getenv("NEO4J_PASSWORD")
+            # Use Pydantic config for Neo4j settings (avoids env var divergence)
+            from kosmos.config import get_config
+            try:
+                config = get_config()
+                uri = config.neo4j.uri
+                user = config.neo4j.user
+                password = config.neo4j.password
+            except Exception:
+                uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+                user = os.getenv("NEO4J_USER", "neo4j")
+                password = os.getenv("NEO4J_PASSWORD")
 
             if not password:
                 return {

--- a/kosmos/api/websocket.py
+++ b/kosmos/api/websocket.py
@@ -226,10 +226,10 @@ if HAS_FASTAPI:
 
                     if action == "ping":
                         # Respond to ping
-                        from datetime import datetime
+                        from datetime import datetime, timezone
                         await websocket.send_json({
                             "action": "pong",
-                            "timestamp": datetime.utcnow().isoformat() + "Z"
+                            "timestamp": datetime.now(timezone.utc).isoformat() + "Z"
                         })
 
                     elif action == "subscribe":

--- a/kosmos/cli/commands/history.py
+++ b/kosmos/cli/commands/history.py
@@ -5,7 +5,7 @@ Browse past research runs and view detailed history.
 """
 
 from typing import Optional
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import typer
 from rich.prompt import Prompt
@@ -123,7 +123,7 @@ def get_research_runs(
                 query = query.filter(ResearchRun.state == status)
 
             if days:
-                cutoff_date = datetime.utcnow() - timedelta(days=days)
+                cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
                 query = query.filter(ResearchRun.created_at >= cutoff_date)
 
             # Order by most recent and limit

--- a/kosmos/cli/commands/run.py
+++ b/kosmos/cli/commands/run.py
@@ -14,7 +14,7 @@ import time
 import logging
 import asyncio
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import typer
@@ -285,7 +285,7 @@ async def run_with_progress_async(
 
         table.add_row("Workflow State", create_status_text(state))
         table.add_row("Iteration", f"{iteration}/{max_iterations}")
-        table.add_row("Started", format_timestamp(datetime.utcnow()))
+        table.add_row("Started", format_timestamp(datetime.now(timezone.utc)))
 
         return table
 

--- a/kosmos/cli/utils.py
+++ b/kosmos/cli/utils.py
@@ -5,7 +5,7 @@ Provides common formatting, database helpers, and utility functions
 used across all CLI commands.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Any, Dict, List
 from contextlib import contextmanager
@@ -43,7 +43,7 @@ def format_timestamp(dt: datetime, relative: bool = True) -> str:
         Formatted timestamp string
     """
     if relative:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         diff = now - dt
 
         if diff.total_seconds() < 60:

--- a/kosmos/core/cache.py
+++ b/kosmos/core/cache.py
@@ -11,7 +11,7 @@ import pickle
 import threading
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional, Dict, Tuple, List
 import logging
@@ -241,7 +241,7 @@ class InMemoryCache(BaseCache):
 
     def _is_expired(self, expires_at: datetime) -> bool:
         """Check if a cached item has expired."""
-        return datetime.utcnow() > expires_at
+        return datetime.now(timezone.utc) > expires_at
 
     def get(self, key: str) -> Optional[Any]:
         """
@@ -287,7 +287,7 @@ class InMemoryCache(BaseCache):
         with self._lock:
             try:
                 # Calculate expiration
-                expires_at = datetime.utcnow() + timedelta(seconds=self.ttl_seconds)
+                expires_at = datetime.now(timezone.utc) + timedelta(seconds=self.ttl_seconds)
 
                 # Remove oldest if at capacity
                 if len(self._cache) >= self.max_size and key not in self._cache:
@@ -352,7 +352,7 @@ class InMemoryCache(BaseCache):
             Number of entries removed
         """
         with self._lock:
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             expired_keys = [
                 key for key, (_, expires_at) in self._cache.items()
                 if expires_at < now
@@ -410,7 +410,7 @@ class DiskCache(BaseCache):
     def _is_expired(self, cached_at: datetime) -> bool:
         """Check if a cached item has expired."""
         expiry = cached_at + timedelta(seconds=self.ttl_seconds)
-        return datetime.utcnow() > expiry
+        return datetime.now(timezone.utc) > expiry
 
     def get(self, key: str) -> Optional[Any]:
         """
@@ -470,7 +470,7 @@ class DiskCache(BaseCache):
                 cached_data = {
                     'key': key,
                     'value': value,
-                    'cached_at': datetime.utcnow()
+                    'cached_at': datetime.now(timezone.utc)
                 }
 
                 with open(cache_path, 'wb') as f:

--- a/kosmos/core/convergence.py
+++ b/kosmos/core/convergence.py
@@ -7,7 +7,7 @@ Implements mandatory and optional stopping criteria:
 """
 
 from typing import List, Dict, Optional, Any, Tuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pydantic import BaseModel, Field
 from enum import Enum
 import logging
@@ -64,12 +64,12 @@ class ConvergenceMetrics(BaseModel):
     cost_per_discovery: Optional[float] = None
 
     # Timestamps
-    start_time: datetime = Field(default_factory=datetime.utcnow)
-    last_update: datetime = Field(default_factory=datetime.utcnow)
+    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_update: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def update_timestamp(self):
         """Update last_update timestamp."""
-        self.last_update = datetime.utcnow()
+        self.last_update = datetime.now(timezone.utc)
 
 
 class StoppingDecision(BaseModel):
@@ -80,7 +80,7 @@ class StoppingDecision(BaseModel):
     is_mandatory: bool  # True if mandatory criterion, False if optional
     confidence: float = Field(1.0, ge=0.0, le=1.0, description="Confidence in decision")
     details: str = ""
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class ConvergenceReport(BaseModel):
@@ -113,7 +113,7 @@ class ConvergenceReport(BaseModel):
     summary: str = ""
     detailed_report: str = ""
 
-    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def to_markdown(self) -> str:
         """Export report as markdown."""

--- a/kosmos/core/events.py
+++ b/kosmos/core/events.py
@@ -7,7 +7,7 @@ Events are published via EventBus and consumed by CLI, API endpoints, and logger
 
 import json
 from dataclasses import dataclass, field, asdict
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -53,7 +53,7 @@ class EventType(str, Enum):
 
 def _default_timestamp() -> str:
     """Generate ISO timestamp with Z suffix."""
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(timezone.utc).isoformat() + "Z"
 
 
 @dataclass

--- a/kosmos/core/feedback.py
+++ b/kosmos/core/feedback.py
@@ -9,7 +9,7 @@ Processes results and generates feedback signals to:
 """
 
 from typing import List, Dict, Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field
 from enum import Enum
 import logging
@@ -39,7 +39,7 @@ class FeedbackSignal(BaseModel):
     source: str  # Result ID or analysis ID
     data: Dict[str, Any]
     confidence: float = Field(1.0, ge=0.0, le=1.0)
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     applied: bool = False
 
 
@@ -55,8 +55,8 @@ class SuccessPattern(BaseModel):
     success_rate: float = 1.0
     confidence: float = 0.5
     examples: List[str] = Field(default_factory=list)  # Result IDs
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class FailurePattern(BaseModel):
@@ -69,8 +69,8 @@ class FailurePattern(BaseModel):
     recommended_fixes: List[str] = Field(default_factory=list)
     occurrences: int = 1
     examples: List[str] = Field(default_factory=list)  # Result IDs
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class FeedbackLoop:
@@ -171,7 +171,7 @@ class FeedbackLoop:
                     existing_pattern.occurrences
                 )
                 existing_pattern.confidence = min(1.0, existing_pattern.confidence + 0.1)
-                existing_pattern.updated_at = datetime.utcnow()
+                existing_pattern.updated_at = datetime.now(timezone.utc)
 
                 pattern_id = existing_pattern.pattern_id
             else:
@@ -219,7 +219,7 @@ class FeedbackLoop:
                 # Update existing pattern
                 existing_pattern.occurrences += 1
                 existing_pattern.examples.append(result.id)
-                existing_pattern.updated_at = datetime.utcnow()
+                existing_pattern.updated_at = datetime.now(timezone.utc)
 
                 pattern_id = existing_pattern.pattern_id
             else:

--- a/kosmos/core/logging.py
+++ b/kosmos/core/logging.py
@@ -15,7 +15,7 @@ import logging.handlers
 import json
 import sys
 from typing import Optional, Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from enum import Enum
 
@@ -49,7 +49,7 @@ class JSONFormatter(logging.Formatter):
             str: JSON formatted log
         """
         log_data = {
-            "timestamp": datetime.utcfromtimestamp(record.created).isoformat(),
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),
@@ -278,7 +278,7 @@ class ExperimentLogger:
 
     def start(self):
         """Log experiment start."""
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(timezone.utc)
         self.logger.info(f"Experiment {self.experiment_id} started", extra={
             "experiment_id": self.experiment_id,
             "event": "start",
@@ -290,7 +290,7 @@ class ExperimentLogger:
         event = {
             "event": "hypothesis",
             "hypothesis": hypothesis,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
         self.events.append(event)
         self.logger.info(f"Hypothesis: {hypothesis}", extra={
@@ -303,7 +303,7 @@ class ExperimentLogger:
         event = {
             "event": "experiment_design",
             "design": design,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
         self.events.append(event)
         self.logger.info("Experiment design created", extra={
@@ -315,7 +315,7 @@ class ExperimentLogger:
         """Log execution start."""
         event = {
             "event": "execution_start",
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
         self.events.append(event)
         self.logger.info("Execution started", extra={
@@ -328,7 +328,7 @@ class ExperimentLogger:
         event = {
             "event": "result",
             "result": result,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
         self.events.append(event)
         self.logger.info("Result obtained", extra={
@@ -341,7 +341,7 @@ class ExperimentLogger:
         event = {
             "event": "error",
             "error": error,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
         self.events.append(event)
         self.logger.error(f"Error: {error}", extra={
@@ -356,7 +356,7 @@ class ExperimentLogger:
         Args:
             status: Final status (success, failure, error)
         """
-        self.end_time = datetime.utcnow()
+        self.end_time = datetime.now(timezone.utc)
         duration = (self.end_time - self.start_time).total_seconds() if self.start_time else 0
 
         self.logger.info(f"Experiment {self.experiment_id} ended: {status}", extra={

--- a/kosmos/core/memory.py
+++ b/kosmos/core/memory.py
@@ -9,7 +9,7 @@ Categories:
 """
 
 from typing import List, Dict, Optional, Any, Tuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pydantic import BaseModel, Field
 from enum import Enum
 import logging
@@ -42,14 +42,14 @@ class Memory(BaseModel):
     data: Dict[str, Any] = Field(default_factory=dict)
     importance: float = Field(0.5, ge=0.0, le=1.0, description="Importance score")
     access_count: int = 0
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    last_accessed: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_accessed: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     tags: List[str] = Field(default_factory=list)
 
     def access(self):
         """Record memory access."""
         self.access_count += 1
-        self.last_accessed = datetime.utcnow()
+        self.last_accessed = datetime.now(timezone.utc)
 
 
 class ExperimentSignature(BaseModel):
@@ -60,7 +60,7 @@ class ExperimentSignature(BaseModel):
     combined_hash: str
     hypothesis_id: Optional[str] = None
     protocol_id: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class MemoryStore:
@@ -130,7 +130,7 @@ class MemoryStore:
         """
         # Generate memory ID
         memory_id = hashlib.md5(
-            f"{category}:{content}:{datetime.utcnow().isoformat()}".encode()
+            f"{category}:{content}:{datetime.now(timezone.utc).isoformat()}".encode()
         ).hexdigest()[:16]
 
         memory = Memory(
@@ -337,7 +337,7 @@ class MemoryStore:
 
         # Sort by importance * recency
         results.sort(
-            key=lambda m: m.importance * (1.0 / max(1, (datetime.utcnow() - m.created_at).days + 1)),
+            key=lambda m: m.importance * (1.0 / max(1, (datetime.now(timezone.utc) - m.created_at).days + 1)),
             reverse=True
         )
 
@@ -494,7 +494,7 @@ class MemoryStore:
         # 2. Recent (< prune_after_days)
         # 3. Frequently accessed (access_count > 0)
 
-        cutoff_date = datetime.utcnow() - timedelta(days=self.prune_after_days)
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=self.prune_after_days)
 
         kept = []
         pruned_count = 0

--- a/kosmos/core/metrics.py
+++ b/kosmos/core/metrics.py
@@ -11,7 +11,7 @@ Tracks:
 """
 
 from typing import Dict, Any, List, Optional, Callable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 import threading
 import logging
@@ -49,7 +49,7 @@ class BudgetAlert:
         """
         self.threshold_percent = threshold_percent
         self.message = message
-        self.triggered_at = triggered_at or datetime.utcnow()
+        self.triggered_at = triggered_at or datetime.now(timezone.utc)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
@@ -121,7 +121,7 @@ class MetricsCollector:
     def __init__(self):
         """Initialize metrics collector."""
         self._lock = threading.Lock()
-        self.start_time = datetime.utcnow()
+        self.start_time = datetime.now(timezone.utc)
 
         # API metrics
         self.api_calls = 0
@@ -158,7 +158,7 @@ class MetricsCollector:
         self.budget_limit_usd: Optional[float] = None
         self.budget_limit_requests: Optional[int] = None
         self.budget_period = BudgetPeriod.DAILY
-        self.budget_period_start = datetime.utcnow()
+        self.budget_period_start = datetime.now(timezone.utc)
         self.budget_alert_thresholds = [50.0, 75.0, 90.0, 100.0]  # Percentage thresholds
         self.budget_alerts: List[BudgetAlert] = []
         self.alert_callbacks: List[Callable[[BudgetAlert], None]] = []
@@ -202,7 +202,7 @@ class MetricsCollector:
 
             # Store in history
             self.api_call_history.append({
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "model": model,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
@@ -267,7 +267,7 @@ class MetricsCollector:
                 "experiment_id": experiment_id,
                 "experiment_type": experiment_type,
                 "status": "running",
-                "start_time": datetime.utcnow().isoformat(),
+                "start_time": datetime.now(timezone.utc).isoformat(),
                 "end_time": None,
                 "duration_seconds": None
             })
@@ -298,7 +298,7 @@ class MetricsCollector:
             for exp in reversed(self.experiment_history):
                 if exp["experiment_id"] == experiment_id:
                     exp["status"] = status
-                    exp["end_time"] = datetime.utcnow().isoformat()
+                    exp["end_time"] = datetime.now(timezone.utc).isoformat()
                     exp["duration_seconds"] = duration_seconds
                     break
 
@@ -385,7 +385,7 @@ class MetricsCollector:
 
             # Store in history
             self.cache_hit_history.append({
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "cache_type": cache_type,
                 "event_type": "hit"
             })
@@ -406,7 +406,7 @@ class MetricsCollector:
 
             # Store in history
             self.cache_hit_history.append({
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "cache_type": cache_type,
                 "event_type": "miss"
             })
@@ -537,7 +537,7 @@ class MetricsCollector:
             dict: System statistics
         """
         with self._lock:
-            uptime = (datetime.utcnow() - self.start_time).total_seconds()
+            uptime = (datetime.now(timezone.utc) - self.start_time).total_seconds()
 
             return {
                 "start_time": self.start_time.isoformat(),
@@ -589,7 +589,7 @@ class MetricsCollector:
             self.budget_limit_usd = limit_usd
             self.budget_limit_requests = limit_requests
             self.budget_period = period
-            self.budget_period_start = datetime.utcnow()
+            self.budget_period_start = datetime.now(timezone.utc)
 
             if alert_thresholds is not None:
                 self.budget_alert_thresholds = sorted(alert_thresholds)
@@ -724,7 +724,7 @@ class MetricsCollector:
 
     def _check_period_reset(self):
         """Check if budget period should be reset."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         time_since_start = now - self.budget_period_start
 
         should_reset = False
@@ -845,7 +845,7 @@ class MetricsCollector:
         Returns:
             dict: Recent activity summary
         """
-        cutoff_time = datetime.utcnow() - timedelta(minutes=minutes)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(minutes=minutes)
 
         with self._lock:
             # Recent API calls
@@ -902,7 +902,7 @@ class MetricsCollector:
             dict: Complete metrics dump
         """
         return {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "statistics": self.get_statistics(),
             "recent_activity": self.get_recent_activity(),
             "api_call_history": self.api_call_history[-100:],  # Last 100

--- a/kosmos/core/providers/anthropic.py
+++ b/kosmos/core/providers/anthropic.py
@@ -174,8 +174,8 @@ class AnthropicProvider(LLMProvider):
                 from kosmos.config import get_config
                 config = get_config()
                 log_llm = config.logging.log_llm_calls
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Config loading for LLM call logging failed: {e}")
 
             # Model selection logic
             selected_model = self.model
@@ -413,8 +413,8 @@ class AnthropicProvider(LLMProvider):
                         "[LLM] Anthropic async: model=%s, in=%d, out=%d, duration=%.2fs",
                         self.model, input_tokens, output_tokens, duration
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Anthropic call logging failed: {e}")
 
             return LLMResponse(
                 content=content,

--- a/kosmos/core/providers/openai.py
+++ b/kosmos/core/providers/openai.py
@@ -353,8 +353,8 @@ class OpenAIProvider(LLMProvider):
                         "[LLM] OpenAI async: model=%s, in=%d, out=%d, duration=%.2fs",
                         self.model, input_tokens, output_tokens, duration
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"OpenAI call logging failed: {e}")
 
             return LLMResponse(
                 content=content,

--- a/kosmos/core/stage_tracker.py
+++ b/kosmos/core/stage_tracker.py
@@ -10,7 +10,7 @@ import logging
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional, Literal, List
 
@@ -93,7 +93,7 @@ class StageTracker:
 
         start = time.time()
         event = StageEvent(
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.now(timezone.utc).isoformat() + "Z",
             process_id=self.process_id,
             stage=stage,
             status="started",
@@ -128,7 +128,7 @@ class StageTracker:
             return
 
         event = StageEvent(
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=datetime.now(timezone.utc).isoformat() + "Z",
             process_id=self.process_id,
             stage=parent_stage,
             substage=substage,

--- a/kosmos/core/workflow.py
+++ b/kosmos/core/workflow.py
@@ -8,7 +8,7 @@ INITIALIZING → GENERATING_HYPOTHESES → DESIGNING_EXPERIMENTS → EXECUTING
 
 from enum import Enum
 from typing import List, Dict, Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field, ConfigDict
 import logging
 
@@ -50,7 +50,7 @@ class WorkflowTransition(BaseModel):
     from_state: WorkflowState
     to_state: WorkflowState
     action: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
@@ -86,8 +86,8 @@ class ResearchPlan(BaseModel):
     convergence_reason: Optional[str] = None
 
     # Timestamps
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # Additional metadata
     success_criteria: Dict[str, Any] = Field(default_factory=dict)
@@ -95,7 +95,7 @@ class ResearchPlan(BaseModel):
 
     def update_timestamp(self):
         """Update the updated_at timestamp."""
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def add_hypothesis(self, hypothesis_id: str):
         """Add hypothesis to pool."""
@@ -287,15 +287,15 @@ class ResearchWorkflow:
         time_in_state = 0.0
         if self.transition_history:
             last_transition = self.transition_history[-1]
-            time_in_state = (datetime.utcnow() - last_transition.timestamp).total_seconds()
+            time_in_state = (datetime.now(timezone.utc) - last_transition.timestamp).total_seconds()
 
         # Log workflow transition if enabled
         log_transitions = False
         try:
             from kosmos.config import get_config
             log_transitions = get_config().logging.log_workflow_transitions
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Config loading for workflow transitions failed: {e}")
 
         if log_transitions:
             logger.debug(
@@ -387,7 +387,7 @@ class ResearchWorkflow:
 
                 # If still in this state, use current time
                 if end_time is None and self.current_state == state:
-                    end_time = datetime.utcnow()
+                    end_time = datetime.now(timezone.utc)
 
                 if end_time:
                     duration = (end_time - transition.timestamp).total_seconds()

--- a/kosmos/db/models.py
+++ b/kosmos/db/models.py
@@ -12,7 +12,7 @@ Models:
 from sqlalchemy import Column, String, Integer, Float, Boolean, Text, DateTime, ForeignKey, JSON, Enum as SQLEnum
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from datetime import datetime
+from datetime import datetime, timezone
 import enum
 
 
@@ -60,7 +60,7 @@ class Experiment(Base):
     error_message = Column(Text, nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     started_at = Column(DateTime, nullable=True)
     completed_at = Column(DateTime, nullable=True)
 
@@ -97,8 +97,8 @@ class Hypothesis(Base):
     related_papers = Column(JSON, nullable=True)  # List of paper IDs
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     # Relationships
     experiments = relationship("Experiment", back_populates="hypothesis")
@@ -136,7 +136,7 @@ class Result(Base):
     figures = Column(JSON, nullable=True)  # Paths to generated figures
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     # Relationships
     experiment = relationship("Experiment", back_populates="results")
@@ -179,7 +179,7 @@ class Paper(Base):
     embedding = Column(JSON, nullable=True)  # Vector embedding
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     analyzed_at = Column(DateTime, nullable=True)
 
     def __repr__(self):
@@ -211,8 +211,8 @@ class AgentRecord(Base):
     errors_encountered = Column(Integer, default=0)
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     stopped_at = Column(DateTime, nullable=True)
 
     def __repr__(self):
@@ -245,8 +245,8 @@ class ResearchSession(Base):
     autonomous_mode = Column(Boolean, default=True)
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     completed_at = Column(DateTime, nullable=True)
 
     def __repr__(self):

--- a/kosmos/db/operations.py
+++ b/kosmos/db/operations.py
@@ -16,7 +16,7 @@ from kosmos.db.models import (
     Experiment, Hypothesis, Result, Paper, AgentRecord, ResearchSession,
     ExperimentStatus, HypothesisStatus
 )
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import time
 
@@ -183,7 +183,7 @@ def update_hypothesis_status(
         raise ValueError(f"Hypothesis {hypothesis_id} not found")
 
     hypothesis.status = status
-    hypothesis.updated_at = datetime.utcnow()
+    hypothesis.updated_at = datetime.now(timezone.utc)
     session.commit()
     session.refresh(hypothesis)
 
@@ -316,9 +316,9 @@ def update_experiment_status(
 
     experiment.status = status
     if status == ExperimentStatus.RUNNING and not experiment.started_at:
-        experiment.started_at = datetime.utcnow()
+        experiment.started_at = datetime.now(timezone.utc)
     elif status in [ExperimentStatus.COMPLETED, ExperimentStatus.FAILED]:
-        experiment.completed_at = datetime.utcnow()
+        experiment.completed_at = datetime.now(timezone.utc)
 
     if error_message:
         experiment.error_message = error_message
@@ -519,13 +519,13 @@ def update_agent_record(
     if status:
         agent.status = status
         if status == "stopped":
-            agent.stopped_at = datetime.utcnow()
+            agent.stopped_at = datetime.now(timezone.utc)
 
     if state_data is not None:
         _validate_json_dict(state_data, "state_data", required=True)
         agent.state_data = state_data
 
-    agent.updated_at = datetime.utcnow()
+    agent.updated_at = datetime.now(timezone.utc)
     session.commit()
     session.refresh(agent)
 
@@ -584,7 +584,7 @@ def update_research_session(
     if status:
         research_session.status = status
         if status == "completed":
-            research_session.completed_at = datetime.utcnow()
+            research_session.completed_at = datetime.now(timezone.utc)
 
     if iteration is not None:
         research_session.iteration = iteration
@@ -593,7 +593,7 @@ def update_research_session(
     if experiments_completed is not None:
         research_session.experiments_completed = experiments_completed
 
-    research_session.updated_at = datetime.utcnow()
+    research_session.updated_at = datetime.now(timezone.utc)
     db_session.commit()
     db_session.refresh(research_session)
 

--- a/kosmos/execution/docker_manager.py
+++ b/kosmos/execution/docker_manager.py
@@ -411,5 +411,5 @@ class DockerManager:
         """Cleanup on deletion."""
         try:
             self.client.close()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Docker client close during cleanup failed: {e}")

--- a/kosmos/execution/executor.py
+++ b/kosmos/execution/executor.py
@@ -532,8 +532,8 @@ class CodeExecutor:
                 try:
                     profiler._stop_profiling()
                     profile_result = profiler.get_result()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Profiler stop/result retrieval failed: {e}")
 
             execution_time = time.time() - start_time
 
@@ -1036,6 +1036,28 @@ def execute_protocol_code(
     Returns:
         Dictionary with execution results
     """
+    # Check SafetyGuardrails emergency stop before execution
+    try:
+        from kosmos.safety.guardrails import SafetyGuardrails
+        guardrails = SafetyGuardrails()
+        guardrails.sync_from_flag_file()
+        if guardrails.is_emergency_stop_active():
+            return {
+                'success': False,
+                'error': 'Emergency stop is active',
+                'validation_errors': [f"Emergency stop: {guardrails.emergency_stop.reason}"],
+                'validation_warnings': []
+            }
+        # Use guardrails-enforced resource limits for sandbox config
+        if use_sandbox and sandbox_config is None:
+            enforced_limits = guardrails.enforce_resource_limits()
+            sandbox_config = {
+                'memory_limit_mb': enforced_limits.max_memory_mb,
+                'timeout_seconds': enforced_limits.max_execution_time_seconds,
+            }
+    except ImportError:
+        logger.debug("SafetyGuardrails not available, proceeding without guardrails")
+
     # Always validate code safety (F-21)
     validator = CodeValidator(allow_file_read=True)
     report = validator.validate(code)

--- a/kosmos/execution/parallel.py
+++ b/kosmos/execution/parallel.py
@@ -18,7 +18,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_compl
 from typing import List, Dict, Any, Callable, Optional, Tuple
 from dataclasses import dataclass
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 logger = logging.getLogger(__name__)
@@ -282,7 +282,7 @@ def _execute_single_experiment(
     Note:
         This function must be pickleable (top-level function) for multiprocessing.
     """
-    started_at = datetime.utcnow()
+    started_at = datetime.now(timezone.utc)
     start_time = time.time()
 
     try:
@@ -298,7 +298,7 @@ def _execute_single_experiment(
         )
 
         execution_time = time.time() - start_time
-        completed_at = datetime.utcnow()
+        completed_at = datetime.now(timezone.utc)
 
         return ParallelExecutionResult(
             experiment_id=task.experiment_id,
@@ -312,7 +312,7 @@ def _execute_single_experiment(
 
     except Exception as e:
         execution_time = time.time() - start_time
-        completed_at = datetime.utcnow()
+        completed_at = datetime.now(timezone.utc)
 
         logger.error(f"Exception executing {task.experiment_id}: {e}")
 

--- a/kosmos/execution/provenance.py
+++ b/kosmos/execution/provenance.py
@@ -33,8 +33,8 @@ def get_git_sha() -> Optional[str]:
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Git commit hash retrieval failed: {e}")
     return None
 
 

--- a/kosmos/execution/r_executor.py
+++ b/kosmos/execution/r_executor.py
@@ -355,8 +355,8 @@ if (length(.kosmos_results) > 0) {{
             # Clean up container
             try:
                 container.remove(force=True)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"R executor container cleanup failed: {e}")
 
     def _parse_results(self, stdout: str) -> Dict[str, Any]:
         """Parse JSON results from R output."""

--- a/kosmos/execution/result_collector.py
+++ b/kosmos/execution/result_collector.py
@@ -9,7 +9,7 @@ import json
 import sys
 import platform
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any, Tuple
 import logging
 import re
@@ -91,8 +91,8 @@ class ResultCollector:
         metadata = self._create_metadata(
             protocol=protocol,
             execution_output=execution_output,
-            start_time=start_time or datetime.utcnow(),
-            end_time=end_time or datetime.utcnow()
+            start_time=start_time or datetime.now(timezone.utc),
+            end_time=end_time or datetime.now(timezone.utc)
         )
 
         # Extract raw data

--- a/kosmos/experiments/templates/base.py
+++ b/kosmos/experiments/templates/base.py
@@ -7,7 +7,7 @@ Provides abstract base class and registry for experiment templates.
 from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Any, Type
 from pydantic import BaseModel, Field
-from datetime import datetime
+from datetime import datetime, timezone
 import pkgutil
 import importlib
 import inspect
@@ -46,8 +46,8 @@ class TemplateMetadata(BaseModel):
 
     # Authorship
     author: str = Field(default="kosmos", description="Template author")
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    last_updated: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # Usage statistics (tracked by registry)
     times_used: int = Field(default=0, ge=0)

--- a/kosmos/hypothesis/refiner.py
+++ b/kosmos/hypothesis/refiner.py
@@ -8,7 +8,7 @@ Implements hybrid retirement logic:
 """
 
 from typing import List, Dict, Optional, Any, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import logging
 import json
@@ -56,7 +56,7 @@ class HypothesisLineage(BaseModel):
     generation: int = 1
     refinement_reason: Optional[str] = None
     evidence_basis: List[str] = Field(default_factory=list)  # Result IDs
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class HypothesisRefiner:
@@ -379,7 +379,7 @@ Respond with JSON:
                         "action": "refined",
                         "based_on_result": result.id,
                         "changes": refinement.get("changes_made", ""),
-                        "timestamp": datetime.utcnow().isoformat()
+                        "timestamp": datetime.now(timezone.utc).isoformat()
                     }]
                 )
 
@@ -474,7 +474,7 @@ Respond with JSON array:
                             "action": "spawned",
                             "based_on_result": result.id,
                             "relationship": variant_data.get("relationship", ""),
-                            "timestamp": datetime.utcnow().isoformat()
+                            "timestamp": datetime.now(timezone.utc).isoformat()
                         }]
                     )
 
@@ -514,11 +514,11 @@ Respond with JSON array:
             Hypothesis: Updated hypothesis with REJECTED status
         """
         hypothesis.status = HypothesisStatus.REJECTED
-        hypothesis.updated_at = datetime.utcnow()
+        hypothesis.updated_at = datetime.now(timezone.utc)
         hypothesis.evolution_history.append({
             "action": "retired",
             "rationale": rationale,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         })
 
         logger.info(f"Retired hypothesis {hypothesis.id}: {rationale}")
@@ -575,7 +575,7 @@ Respond with JSON array:
                             "hypothesis2_statement": hyp2.statement,
                             "hypothesis1_supported": support1,
                             "hypothesis2_supported": support2,
-                            "detected_at": datetime.utcnow().isoformat()
+                            "detected_at": datetime.now(timezone.utc).isoformat()
                         }
 
                         contradictions.append(contradiction)
@@ -721,7 +721,7 @@ Respond with JSON:
                         "action": "merged",
                         "merged_from": [h.id for h in hypotheses],
                         "synthesis": merge_data.get("synthesis_explanation", ""),
-                        "timestamp": datetime.utcnow().isoformat()
+                        "timestamp": datetime.now(timezone.utc).isoformat()
                     }]
                 )
 

--- a/kosmos/knowledge/vector_db.py
+++ b/kosmos/knowledge/vector_db.py
@@ -91,8 +91,8 @@ class PaperVectorDB:
             try:
                 self.client.delete_collection(name=collection_name)
                 logger.info(f"Reset collection: {collection_name}")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Collection reset deletion failed: {e}")
 
         self.collection = self.client.get_or_create_collection(
             name=collection_name,

--- a/kosmos/literature/cache.py
+++ b/kosmos/literature/cache.py
@@ -8,7 +8,7 @@ and respect rate limits.
 import hashlib
 import json
 import pickle
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional, Dict
 import logging
@@ -100,7 +100,7 @@ class LiteratureCache:
             True if expired, False otherwise
         """
         expiry = cached_at + timedelta(hours=self.ttl_hours)
-        return datetime.utcnow() > expiry
+        return datetime.now(timezone.utc) > expiry
 
     def get(self, source: str, endpoint: str, params: Dict[str, Any]) -> Optional[Any]:
         """
@@ -160,7 +160,7 @@ class LiteratureCache:
                 'endpoint': endpoint,
                 'params': params,
                 'response': response,
-                'cached_at': datetime.utcnow()
+                'cached_at': datetime.now(timezone.utc)
             }
 
             with open(cache_path, 'wb') as f:

--- a/kosmos/literature/unified_search.py
+++ b/kosmos/literature/unified_search.py
@@ -179,8 +179,8 @@ class UnifiedLiteratureSearch:
                         try:
                             papers = future.result(timeout=0)
                             all_papers.extend(papers)
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.warning(f"Paper search future failed: {e}")
 
         logger.info(f"Total papers retrieved (before dedup): {len(all_papers)}")
 

--- a/kosmos/models/experiment.py
+++ b/kosmos/models/experiment.py
@@ -7,7 +7,7 @@ Complements the SQLAlchemy Experiment model in kosmos.db.models.
 
 from typing import List, Optional, Dict, Any, Union
 from pydantic import BaseModel, Field, field_validator, ConfigDict
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import logging
 
@@ -407,8 +407,8 @@ class ExperimentProtocol(BaseModel):
     template_version: Optional[str] = None
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     generated_by: str = Field(default="experiment_designer")
 
     @field_validator('description')
@@ -696,4 +696,4 @@ class ValidationReport(BaseModel):
     summary: str = Field(..., description="Human-readable validation summary")
     recommendations: List[str] = Field(default_factory=list)
 
-    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/kosmos/models/hypothesis.py
+++ b/kosmos/models/hypothesis.py
@@ -7,7 +7,7 @@ Complements the SQLAlchemy Hypothesis model in kosmos.db.models.
 
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field, field_validator, ConfigDict
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 from kosmos.config import _DEFAULT_CLAUDE_SONNET_MODEL
@@ -73,8 +73,8 @@ class Hypothesis(BaseModel):
     related_papers: List[str] = Field(default_factory=list)  # Paper IDs used in generation
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     generated_by: str = Field(default="hypothesis_generator")
 
     # Evolution tracking (Phase 7)
@@ -259,7 +259,7 @@ class NoveltyReport(BaseModel):
     novelty_threshold_used: float = 0.75
     summary: str = Field(..., description="Human-readable summary")
 
-    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class TestabilityReport(BaseModel):
@@ -293,7 +293,7 @@ class TestabilityReport(BaseModel):
     summary: str = Field(..., description="Human-readable summary")
     recommended: bool = Field(..., description="Recommended for testing")
 
-    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class PrioritizedHypothesis(BaseModel):
@@ -328,4 +328,4 @@ class PrioritizedHypothesis(BaseModel):
     def update_hypothesis_priority(self) -> None:
         """Update the hypothesis object with this priority score."""
         self.hypothesis.priority_score = self.priority_score
-        self.hypothesis.updated_at = datetime.utcnow()
+        self.hypothesis.updated_at = datetime.now(timezone.utc)

--- a/kosmos/models/result.py
+++ b/kosmos/models/result.py
@@ -8,7 +8,7 @@ with validation and structured data handling.
 from pydantic import BaseModel, Field, field_validator
 from kosmos.utils.compat import model_to_dict
 from typing import Dict, List, Optional, Any, Union
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import json
 
@@ -200,8 +200,8 @@ class ExperimentResult(BaseModel):
     )
 
     # Timestamps
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Result creation time")
-    updated_at: datetime = Field(default_factory=datetime.utcnow, description="Last update time")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Result creation time")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Last update time")
 
     @field_validator('statistical_tests')
     @classmethod

--- a/kosmos/monitoring/alerts.py
+++ b/kosmos/monitoring/alerts.py
@@ -11,7 +11,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ class Alert:
     name: str
     severity: AlertSeverity
     message: str
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     status: AlertStatus = AlertStatus.ACTIVE
     details: Dict[str, Any] = field(default_factory=dict)
     alert_id: Optional[str] = None
@@ -83,7 +83,7 @@ class AlertRule:
         # Check cooldown
         if self.last_triggered:
             cooldown_end = self.last_triggered + timedelta(seconds=self.cooldown_seconds)
-            if datetime.utcnow() < cooldown_end:
+            if datetime.now(timezone.utc) < cooldown_end:
                 return False
 
         # Check condition
@@ -103,7 +103,7 @@ class AlertRule:
         Returns:
             Alert instance
         """
-        self.last_triggered = datetime.utcnow()
+        self.last_triggered = datetime.now(timezone.utc)
         return Alert(
             name=self.name,
             severity=self.severity,

--- a/kosmos/workflow/ensemble.py
+++ b/kosmos/workflow/ensemble.py
@@ -28,7 +28,7 @@ Example:
 import logging
 from dataclasses import dataclass, field, asdict
 from typing import Dict, List, Optional, Tuple, Any
-from datetime import datetime
+from datetime import datetime, timezone
 import numpy as np
 from collections import defaultdict
 
@@ -825,7 +825,7 @@ class EnsembleRunner:
         """
         import time
         start_time = time.time()
-        start_timestamp = datetime.utcnow().isoformat()
+        start_timestamp = datetime.now(timezone.utc).isoformat()
 
         logger.info(
             f"Starting ensemble run: '{research_objective}' "
@@ -856,7 +856,7 @@ class EnsembleRunner:
         non_convergent = [m for m in matched_findings if not m.is_convergent]
 
         end_time = time.time()
-        end_timestamp = datetime.utcnow().isoformat()
+        end_timestamp = datetime.now(timezone.utc).isoformat()
 
         result = EnsembleResult(
             research_objective=research_objective,
@@ -1096,7 +1096,7 @@ class ConvergenceReporter:
         os.makedirs(self.output_dir, exist_ok=True)
 
         if output_path is None:
-            timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
             ext = "md" if format == "markdown" else "json"
             output_path = os.path.join(self.output_dir, f"convergence_report_{timestamp}.{ext}")
 

--- a/kosmos/world_model/in_memory.py
+++ b/kosmos/world_model/in_memory.py
@@ -7,7 +7,7 @@ that can be used for testing without requiring Neo4j.
 
 import json
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -137,7 +137,7 @@ class InMemoryWorldModel(WorldModelStorage, EntityManager):
 
         export_data = {
             "version": "1.0",
-            "exported_at": datetime.utcnow().isoformat(),
+            "exported_at": datetime.now(timezone.utc).isoformat(),
             "source": "kosmos",
             "mode": "in_memory",
             "project": project,

--- a/kosmos/world_model/simple.py
+++ b/kosmos/world_model/simple.py
@@ -26,7 +26,7 @@ import json
 import logging
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -965,8 +965,8 @@ class Neo4jWorldModel(WorldModelStorage, EntityManager):
                     # Estimate: 500 bytes/node + 200 bytes/relationship + 20% overhead
                     estimated_bytes = (nodes * 500 + rels * 200) * 1.2
                     return round(estimated_bytes / (1024 * 1024), 2)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Neo4j storage size estimation query failed: {e}")
 
         except Exception as e:
             logger.debug(f"Could not determine Neo4j storage size: {e}")
@@ -1062,7 +1062,7 @@ class Neo4jWorldModel(WorldModelStorage, EntityManager):
         ann_dict = {
             'text': annotation.text,
             'created_by': annotation.created_by,
-            'created_at': (annotation.created_at or datetime.utcnow()).isoformat(),
+            'created_at': (annotation.created_at or datetime.now(timezone.utc)).isoformat(),
             'annotation_id': str(uuid.uuid4())  # Unique ID for each annotation
         }
 
@@ -1083,7 +1083,7 @@ class Neo4jWorldModel(WorldModelStorage, EntityManager):
                 query,
                 entity_id=entity_id,
                 annotation=json.dumps(ann_dict),
-                updated_at=datetime.utcnow().isoformat()
+                updated_at=datetime.now(timezone.utc).isoformat()
             ).data()
 
             if result and result[0]['updated'] > 0:


### PR DESCRIPTION
## Summary

Follow-up to PR #86. Fixes the remaining Tier 3 (architecture/robustness) and Tier 4 (deprecated API cleanup) issues identified by the `DEEP_ONBOARD.md` review. 43 files changed across 6 fix categories.

### Tier 3 - Architecture & Robustness

- **Fix 3.2 - execute() signature contract**: Widened `BaseAgent.execute()` to accept `Union[Dict, AgentMessage]`, matching the actual subclass signatures in `HypothesisGeneratorAgent` and `ExperimentDesignerAgent` (Gotcha #5)
- **Fix 3.4 - Silent exception swallowing**: Added `logger.debug()` or `logger.warning()` to 11 silent `except Exception: pass` sites across 10 files, replacing complete error suppression with logged diagnostics (Gotcha #124)
- **Fix 3.5 - Dual-path config reads**: Migrated `health.py` health checks from raw `os.getenv()` to Pydantic `get_config()` with env var fallback, preventing config divergence (Gotcha #55)
- **Fix 3.7 - SafetyGuardrails not wired**: Integrated `SafetyGuardrails` into `execute_protocol_code()` — checks emergency stop status and enforces resource limits before code execution (Gotcha #28)

### Tier 4 - Deprecated API Cleanup

- **Fix 4.2 - datetime.utcnow()**: Replaced ~55 deprecated `datetime.utcnow()` calls with `datetime.now(timezone.utc)` across 22 files for Python 3.12+ compatibility (Gotcha #78)
- **Fix 4.3 - asyncio.get_event_loop()**: Replaced deprecated `asyncio.get_event_loop().run_until_complete()` in `execute_experiments_batch()` with proper async pattern using `get_running_loop()` detection (Gotcha #13)

## Test plan

- [x] All 43 modified files verified with `ast.parse()` (syntax check passed)
- [ ] Run `make test-unit` to verify no regressions
- [ ] Run `make test-smoke` for sanity checks
- [ ] Verify `datetime.now(timezone.utc)` produces equivalent UTC timestamps

https://claude.ai/code/session_01Stp6s5AYLsvghybHSskZtk